### PR TITLE
dependabot: correct location of package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/js"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
> to the projects root instead of ./js.