### PR TITLE
chore: Mark vendor folder as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/**/* linguist-generated=true


### PR DESCRIPTION
> each of the files in it is created by vendoring using `npm run-script build:[...]`.
> 
> This way GitHub does respect these as irrelevant in PR reviews, which should make them easier.
> 
> https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github