### PR TITLE
fix: Provide correct prettier commit revision

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # chore: Use prettier on repo
-641a42df8e8ee0baa0144404c82d356bfe52962c
+baeaf4c7b86a3613c2a5a25428d90806b0d50add


### PR DESCRIPTION
merge rebasing the referenced commit has been done with `--no-fast-forward`, which appears to be githubs default rebase strategy.