### PR TITLE
feat!: Drop IE8 support

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,13 +37,6 @@
 
         <!-- leaflet -->
         <link rel="stylesheet" href="vendor/leaflet/leaflet.css" />
-
-        <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-        <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-        <!--[if lt IE 9]>
-            <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-            <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-        <![endif]-->
     </head>
 
     <body id="page-top" data-spy="scroll" data-target=".fixed-top">

--- a/satzung.html
+++ b/satzung.html
@@ -34,13 +34,6 @@
             rel="stylesheet"
             type="text/css"
         />
-
-        <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-        <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-        <!--[if lt IE 9]>
-            <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-            <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-        <![endif]-->
     </head>
 
     <body id="page-top" data-spy="scroll" data-target=".fixed-top">


### PR DESCRIPTION
> as IE is below 0.03%, wildly unsupported and therefore dropped by bootstrap5 as well.