### PR TITLE
chore: Drop @fontsource/lora as runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
             "name": "fnorden.net",
             "version": "1.0.0",
             "license": "Apache-2.0",
-            "dependencies": {
-                "@fontsource/lora": "^5.1.1"
-            },
             "devDependencies": {
+                "@fontsource/lora": "^5.1.1",
                 "@fontsource/montserrat": "^5.1.1",
                 "@fortawesome/fontawesome-free": "^6.7.2",
                 "bootstrap": "^5.3.3",
@@ -27,7 +25,8 @@
         "node_modules/@fontsource/lora": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/@fontsource/lora/-/lora-5.1.1.tgz",
-            "integrity": "sha512-bUW6bZmbbJG4jjHPaamRhLNmerjck/oXMh0NcdgB0WC1wtJLpBphi51NVh2EwE6UimliUA4o8UPYD/lOtBX36Q=="
+            "integrity": "sha512-bUW6bZmbbJG4jjHPaamRhLNmerjck/oXMh0NcdgB0WC1wtJLpBphi51NVh2EwE6UimliUA4o8UPYD/lOtBX36Q==",
+            "dev": true
         },
         "node_modules/@fontsource/montserrat": {
             "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     },
     "homepage": "https://github.com/freifunkh/fnorden.net#readme",
     "devDependencies": {
+        "@fontsource/lora": "^5.1.1",
         "@fontsource/montserrat": "^5.1.1",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "bootstrap": "^5.3.3",
@@ -36,9 +37,6 @@
         "less": "^4.2.1",
         "prettier": "^3.4.2",
         "svgtofont": "^6.2.0"
-    },
-    "dependencies": {
-        "@fontsource/lora": "^5.1.1"
     },
     "svgtofont": {
         "css": {


### PR DESCRIPTION
> which it wasn't in the first place.
> Having it as development dependency suffices.