### PR TITLE
fix: Update anchor in address bar when link clicked

### DIFF
--- a/js/grayscale.js
+++ b/js/grayscale.js
@@ -28,6 +28,7 @@ $(function () {
                 1500,
                 "easeInOutExpo",
             );
+        window.location.href = $anchor.attr("href");
         event.preventDefault();
     });
 });


### PR DESCRIPTION
Clicking a link in the nav bar scrolls the website but it didn't update the anchor part of the address. It now does, enabling wonderful features like history back.