### PR TITLE
refactor: Swap jquery document.ready

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+document.addEventListener("DOMContentLoaded", function () {
     var map = L.map("map").setView([52.39314088, 9.72286284], 16);
 
     map.scrollWheelZoom.disable();


### PR DESCRIPTION
> in favor of the standardized DOMContentLoaded event. IE8 was the one browser, which did not support this properly and is no longer supported by us.