### PR TITLE
chore: Ignore stargazers of fontsource

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,5 @@ https://badgen.net/npm/dm/@fontsource/lora
 https://badgen.net/npm/dt/@fontsource/lora
 https://badgen.net/npm/dm/@fontsource/montserrat
 https://badgen.net/npm/dt/@fontsource/montserrat
+# GitHub does not allow reaing stargazers for not project members anymore, due to ai scrapers
+https://github.com/fontsource/fontsource/stargazers


### PR DESCRIPTION
which are never served to visitors of fnorden.net anyway.

This omission might be obsolete with the next release of fontsource.