### PR TITLE
ci: Cease usage of script_stop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
                   username: ${{ secrets.SSH_USER }}
                   password: ${{ secrets.SSH_PASSWORD }}
                   port: ${{ secrets.SSH_PORT }}
-                  script_stop: true
                   script: |
+                      set -e
                       cd /var/www/domains/fnorden.net/
                       sudo -u www-data /usr/bin/git pull


### PR DESCRIPTION
in favor of bash option -e, which does the same and exits immediately upon a problem.